### PR TITLE
Remove man pages from image

### DIFF
--- a/exclude
+++ b/exclude
@@ -8,6 +8,7 @@ etc/pacman.d/gnupg/pubring.gpg~
 etc/pacman.d/gnupg/S.*
 root/*
 tmp/*
+usr/share/man/*
 var/cache/pacman/pkg/*
 var/lib/pacman/sync/*
 var/tmp/*


### PR DESCRIPTION
On docker images has no sense have man pages. This reduce image around 10Mb.