### PR TITLE
pacstrap: set up the image using NoExtract rules to prune dead weight

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 *.orig
 /.idea
 /archlinux.tar
+rootfs/etc/pacman.conf

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,9 @@ DOCKER_IMAGE:=base
 
 rootfs:
 	$(eval TMPDIR := $(shell mktemp -d))
-	env -i pacstrap -C /usr/share/devtools/pacman-extra.conf -c -d -G -M $(TMPDIR) $(shell cat packages)
+	cp /usr/share/devtools/pacman-extra.conf rootfs/etc/pacman.conf
+	cat pacman-conf.d-noextract.conf >> rootfs/etc/pacman.conf
+	env -i pacstrap -C rootfs/etc/pacman.conf -c -d -G -M $(TMPDIR) $(shell cat packages)
 	cp --recursive --preserve=timestamps --backup --suffix=.pacnew rootfs/* $(TMPDIR)/
 	arch-chroot $(TMPDIR) locale-gen
 	arch-chroot $(TMPDIR) pacman-key --init

--- a/pacman-conf.d-noextract.conf
+++ b/pacman-conf.d-noextract.conf
@@ -1,0 +1,9 @@
+[options]
+NoExtract  = usr/share/help/* !usr/share/help/en*
+NoExtract  = usr/share/gtk-doc/html/* usr/share/doc/*
+NoExtract  = usr/share/locale/* usr/share/X11/locale/* usr/share/i18n/*
+NoExtract   = !*locale*/en*/* !usr/share/i18n/charmaps/UTF-8.gz !usr/share/*locale*/locale.*
+NoExtract   = !usr/share/*locales/en_?? !usr/share/*locales/i18n* !usr/share/*locales/iso*
+NoExtract   = !usr/share/*locales/trans*
+NoExtract  = usr/share/man/* usr/share/info/*
+NoExtract  = usr/share/vim/vim*/lang/*


### PR DESCRIPTION
A docker container does not need tons of locales in order to do its job, nor does it need extensive (or any) documentation.

With this change, a bare pacstrapped directory drops from 500MB to 390MB

Context: @SantiagoTorres asked about this as part of an effort to make the docker image no longer unusually large as docker containers are measured, with the end goal of achieving something closer to 250MB.