### PR TITLE
add Github Actions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,12 @@
+name: Github-Actions
+
+on: [push, pull_request]
+
+jobs:
+  ci-test:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v1
+    - name: make ci-test
+      run: make ci-test


### PR DESCRIPTION
Github is testing an own Continuous Integration system called "Github Actions". This commit adds a workflow for Github Actions. 

Signed-off-by: Christian Rebischke <chris@nullday.de>