### PR TITLE
Missing lots of users and groups

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # Arch Linux Docker Image
 [![pipeline status](https://gitlab.archlinux.org/archlinux/archlinux-docker/badges/master/pipeline.svg)](https://gitlab.archlinux.org/archlinux/archlinux-docker/-/commits/master)
 
+
 This repository contains all scripts and files needed to create a Docker image for Arch Linux.
 
 ## Dependencies


### PR DESCRIPTION
Hi, how can I open an issue about this docker image? [Dockerhub](https://hub.docker.com/_/archlinux) is pointing me to https://gitlab.archlinux.org/archlinux/archlinux-docker/issues, but that link seems to be for internal people only.

My problem is, recently I am seeing that only `root` is left in the container:
```
$ docker run -it archlinux cat /etc/group /etc/passwd                                                                                                                                                                              
root:x:0:root
root:x:0:0::/root:/bin/bash
```

Is this a bug or a feature? Many software assumes the existence of certain users and groups. And without them could causes lots of bugs, such as:
```
(2/4) Creating temporary files...
/usr/lib/tmpfiles.d/journal-nocow.conf:26: Failed to resolve specifier: uninitialized /etc detected, skipping
All rules containing unresolvable specifiers will be skipped.
/usr/lib/tmpfiles.d/static-nodes-permissions.conf:12: Failed to resolve group 'audio'.
/usr/lib/tmpfiles.d/static-nodes-permissions.conf:13: Failed to resolve group 'audio'.
/usr/lib/tmpfiles.d/static-nodes-permissions.conf:14: Failed to resolve group 'disk'.
/usr/lib/tmpfiles.d/static-nodes-permissions.conf:17: Failed to resolve group 'kvm'.
/usr/lib/tmpfiles.d/systemd.conf:19: Failed to resolve user 'systemd-network': No such process
/usr/lib/tmpfiles.d/systemd.conf:20: Failed to resolve user 'systemd-network': No such process
/usr/lib/tmpfiles.d/systemd.conf:21: Failed to resolve user 'systemd-network': No such process
/usr/lib/tmpfiles.d/systemd.conf:22: Failed to resolve user 'systemd-network': No such process
/usr/lib/tmpfiles.d/systemd.conf:26: Failed to resolve group 'systemd-journal'.
Failed to parse ACL "d:group::r-x,d:group:adm:r-x,d:group:wheel:r-x,group::r-x,group:adm:r-x,group:wheel:r-x": No such process. Ignoring
/usr/lib/tmpfiles.d/systemd.conf:33: Failed to resolve group 'systemd-journal'.
Failed to parse ACL "d:group::r-x,d:group:adm:r-x,d:group:wheel:r-x,group::r-x,group:adm:r-x,group:wheel:r-x": No such process. Ignoring
/usr/lib/tmpfiles.d/var.conf:15: Failed to resolve group 'utmp'.
/usr/lib/tmpfiles.d/var.conf:16: Failed to resolve group 'utmp'.
/usr/lib/tmpfiles.d/var.conf:17: Failed to resolve group 'utmp'.
```