### PR TITLE
Archlinux docker does not work with github actions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 # Arch Linux Docker Image
 
+
 [![pipeline status](https://gitlab.archlinux.org/archlinux/archlinux-docker/badges/master/pipeline.svg)](https://gitlab.archlinux.org/archlinux/archlinux-docker/-/commits/master)
 
 Arch Linux provides Docker images both in the [official DockerHub library](https://hub.docker.com/_/archlinux) (`docker pull library/archlinux:latest`) and in our [own repository](https://hub.docker.com/r/archlinux/archlinux) (`docker pull archlinux/archlinux:latest`).


### PR DESCRIPTION
Hi, sorry that I have to report a bug here, because gitlab requires an archlinux sso account, which I don't have.

It looks like `pacman` of archlinux docker fails to work with github actions. Please see https://github.com/zasdfgbnm/archlinux-pacman-action-bug for a repro, the workflow to see is https://github.com/zasdfgbnm/archlinux-pacman-action-bug/actions/runs/576905025

The problem is:

The following command succeeds:
```
sudo docker run --privileged archlinux:base pacman -Syu --noconfirm
```

The following command fails:
```
sudo docker run archlinux:base pacman -Syu --noconfirm
```

The following command also fails:
```
docker build .
```
where the Dockerfile is
```Dockerfile
FROM archlinux:base
RUN pacman -Syu --noconfirm
```

When failing, the error is
```
error: failed to initialize alpm library
(could not find or read directory: /var/lib/pacman/)
Error: Process completed with exit code 255.
```