### PR TITLE
Remove the deprecated UseDelta flag

### DIFF
--- a/pacman.conf
+++ b/pacman.conf
@@ -19,7 +19,6 @@
 #XferCommand = /usr/bin/curl -C - -f %u > %o
 #XferCommand = /usr/bin/wget --passive-ftp -c -O %o %u
 #CleanMethod = KeepInstalled
-#UseDelta    = 0.7
 Architecture = auto
 
 # Pacman won't upgrade packages listed in IgnorePkg and members of IgnoreGroup


### PR DESCRIPTION
This flag has been removed in pacman. See the below commits in https://git.archlinux.org/pacman.git/

c0e9be7973be6c81b22fde91516fb8991e7bb07b
e7bb0f8824a916c1537dd83735cd8aeccdcd0f3f